### PR TITLE
Added some validation and error checks

### DIFF
--- a/mloop_interface.py
+++ b/mloop_interface.py
@@ -3,7 +3,6 @@ from runmanager.remote import set_globals, engage
 import mloop_config
 from mloop.interfaces import Interface
 from mloop.controllers import create_controller
-from mloop_multishot import check_runmanager
 
 
 def set_globals_mloop(mloop_session=None, mloop_iteration=None):
@@ -40,12 +39,6 @@ class LoopInterface(Interface):
         # or so mloop_multishot.py can fake a cost if mock = True
         lyse.routine_storage.params = params_dict['params']
 
-        if not check_runmanager(self.config):
-            print(
-                'Error in runmanager (above).',
-                'Please remedy above before submitting next shot to lyse.',
-            )
-            return {'cost': None}
         if not self.config['mock']:
             print('Requesting next shot from experiment interface...')
             globals_dict = dict(zip(self.config['mloop_params'], params_dict['params']))

--- a/mloop_interface.py
+++ b/mloop_interface.py
@@ -3,6 +3,7 @@ from runmanager.remote import set_globals, engage
 import mloop_config
 from mloop.interfaces import Interface
 from mloop.controllers import create_controller
+from mloop_multishot import check_runmanager
 
 
 def set_globals_mloop(mloop_session=None, mloop_iteration=None):
@@ -35,15 +36,22 @@ class LoopInterface(Interface):
     # associated with a given point in the search space
     def get_next_cost_dict(self, params_dict):
         self.num_in_costs += 1
+        # Store current parameters to later verify reported cost corresponds to these
+        # or so mloop_multishot.py can fake a cost if mock = True
+        lyse.routine_storage.params = params_dict['params']
+
+        if not check_runmanager(self.config):
+            print(
+                'Error in runmanager (above).',
+                'Please remedy above before submitting next shot to lyse.',
+            )
+            return {'cost': None}
         if not self.config['mock']:
             print('Requesting next shot from experiment interface...')
             globals_dict = dict(zip(self.config['mloop_params'], params_dict['params']))
             set_globals(globals_dict)
             set_globals_mloop(mloop_iteration=self.num_in_costs)
             engage()
-        else:
-            # Store a current parameter so that mloop_multishot.py can fake a cost
-            lyse.routine_storage.x = params_dict['params'][0]
 
         # Only proceed once per execution of the mloop_multishot.py routine
         print('Getting current cost from lyse queue...')

--- a/mloop_multishot.py
+++ b/mloop_multishot.py
@@ -25,11 +25,11 @@ def check_runmanager(config):
     n_shots = rm.n_shots()
     if n_shots > 1 and not config['ignore_bad']:
         msgs.append(
-            f'runmanager set to compile {n_shots:d} shots per request, but your '
+            f'runmanager is set to compile {n_shots:d} shots per request, but your '
             + 'mloop_config has ignore_bad = False. You are advised to (i) remove '
-            + 'iterable globals so as to compile one shot per cost; or set ignore_bad '
-            + '= True in your mloop_config and only return one cost with bad = False '
-            + 'per sequence.'
+            + 'iterable globals so as to compile one shot per cost or (ii) set '
+            + 'ignore_bad = True in your mloop_config and only return one cost with '
+            + 'bad = False per sequence.'
         )
     if len(msgs) > 1:
         print('\n'.join(msgs))

--- a/mloop_multishot.py
+++ b/mloop_multishot.py
@@ -29,7 +29,7 @@ def check_runmanager(config):
             + 'mloop_config has ignore_bad = False. You are advised to (i) remove '
             + 'iterable globals so as to compile one shot per cost; or set ignore_bad '
             + '= True in your mloop_config and only return one cost with bad = False '
-            + ' per sequence.'
+            + 'per sequence.'
         )
     if len(msgs) > 1:
         print('\n'.join(msgs))
@@ -53,11 +53,11 @@ def verify_globals(config):
     shot_values = [shot_globals[name] for name in config['mloop_params']]
 
     # Verify integrity by cross-checking against what was requested
-    if current_values != requested_values:
+    if not np.array_equal(current_values, requested_values):
         print('Cost requested for different values to those in runmanager.')
         print('Please add an executed shot to lyse with: ', requested_dict)
         return False
-    if shot_values != requested_values:
+    if not np.array_equal(shot_values, requested_values):
         print('Cost requested for different values to those used to compute cost.')
         print('Please add an executed shot to lyse with: ', requested_dict)
         return False
@@ -124,7 +124,7 @@ if __name__ == '__main__':
             maximize=config['maximize'],
             x=lyse.routine_storage.params[0] if config['mock'] else None,
         )
-        if verify_globals(config) and (not cost_dict['bad'] or not config['ignore_bad']):
+        if (not cost_dict['bad'] or not config['ignore_bad']) and verify_globals(config):
             lyse.routine_storage.queue.put(cost_dict)
         check_runmanager(config)
     elif check_runmanager(config):

--- a/mloop_multishot.py
+++ b/mloop_multishot.py
@@ -1,4 +1,5 @@
 import lyse
+import runmanager.remote as rm
 import numpy as np
 import mloop_config
 
@@ -10,6 +11,57 @@ except ImportError:
 check_version('lyse', '2.5.0', '3.0')
 check_version('zprocess', '2.13.1', '3.0')
 check_version('labscript_utils', '2.12.5', '3.0')
+
+
+def check_runmanager(config):
+    msgs = ['WARNING(s):']
+    rm_globals = rm.get_globals()
+    if not all([x in rm_globals for x in config['mloop_params']]):
+        msgs.append('Not all optimisation parameters present in runmanager.')
+    if not rm.get_run_shots():
+        msgs.append('Run shot(s) not selected in runmanager.')
+    if rm.error_in_globals():
+        msgs.append('Error in runmanager globals.')
+    n_shots = rm.n_shots()
+    if n_shots > 1 and not config['ignore_bad']:
+        msgs.append(
+            f'runmanager set to compile {n_shots:d} shots per request, but your '
+            + 'mloop_config has ignore_bad = False. You are advised to (i) remove '
+            + 'iterable globals so as to compile one shot per cost; or set ignore_bad '
+            + '= True in your mloop_config and only return one cost with bad = False '
+            + ' per sequence.'
+        )
+    if len(msgs) > 1:
+        print('\n'.join(msgs))
+    return len(msgs) <= 1
+
+
+def verify_globals(config):
+    # Get the current runmanager globals
+    rm_globals = rm.get_globals()
+    current_values = [rm_globals[name] for name in config['mloop_params']]
+
+    # Retrieve the parameter values requested by M-LOOP on this iteration
+    requested_values = lyse.routine_storage.params
+    requested_dict = dict(zip(config['mloop_params'], requested_values))
+
+    # Get the parameter values for the shot we just computed the cost for
+    df = lyse.data()
+    ix = -1
+    run = lyse.Run(df['filepath'].iloc[ix])
+    shot_globals = run.get_globals()
+    shot_values = [shot_globals[name] for name in config['mloop_params']]
+
+    # Verify integrity by cross-checking against what was requested
+    if current_values != requested_values:
+        print('Cost requested for different values to those in runmanager.')
+        print('Please add an executed shot to lyse with: ', requested_dict)
+        return False
+    if shot_values != requested_values:
+        print('Cost requested for different values to those used to compute cost.')
+        print('Please add an executed shot to lyse with: ', requested_dict)
+        return False
+    return True
 
 
 def cost_analysis(cost_key=(None,), maximize=True, x=None):
@@ -70,11 +122,12 @@ if __name__ == '__main__':
         cost_dict = cost_analysis(
             cost_key=config['cost_key'] if not config['mock'] else [],
             maximize=config['maximize'],
-            x=lyse.routine_storage.x if config['mock'] else None,
+            x=lyse.routine_storage.params[0] if config['mock'] else None,
         )
-        if not cost_dict['bad'] or not config['ignore_bad']:
+        if verify_globals(config) and (not cost_dict['bad'] or not config['ignore_bad']):
             lyse.routine_storage.queue.put(cost_dict)
-    else:
+        check_runmanager(config)
+    elif check_runmanager(config):
         print('(Re)starting optimisation process...')
         import threading
         import mloop_interface
@@ -84,3 +137,8 @@ if __name__ == '__main__':
         )
         lyse.routine_storage.optimisation.daemon = True
         lyse.routine_storage.optimisation.start()
+    else:
+        print(
+            '\nNot (re)starting optimisation process.',
+            'Please address above warnings before trying again.',
+        )

--- a/mloop_multishot.py
+++ b/mloop_multishot.py
@@ -47,10 +47,7 @@ def verify_globals(config):
 
     # Get the parameter values for the shot we just computed the cost for
     df = lyse.data()
-    ix = -1
-    run = lyse.Run(df['filepath'].iloc[ix])
-    shot_globals = run.get_globals()
-    shot_values = [shot_globals[name] for name in config['mloop_params']]
+    shot_values = [df[name].iloc[-1] for name in config['mloop_params']]
 
     # Verify integrity by cross-checking against what was requested
     if not np.array_equal(current_values, requested_values):
@@ -124,7 +121,9 @@ if __name__ == '__main__':
             maximize=config['maximize'],
             x=lyse.routine_storage.params[0] if config['mock'] else None,
         )
-        if (not cost_dict['bad'] or not config['ignore_bad']) and verify_globals(config):
+        if (not cost_dict['bad'] or not config['ignore_bad']) and verify_globals(
+            config
+        ):
             lyse.routine_storage.queue.put(cost_dict)
         check_runmanager(config)
     elif check_runmanager(config):

--- a/mloop_multishot.py
+++ b/mloop_multishot.py
@@ -121,11 +121,12 @@ if __name__ == '__main__':
             maximize=config['maximize'],
             x=lyse.routine_storage.params[0] if config['mock'] else None,
         )
-        if (not cost_dict['bad'] or not config['ignore_bad']) and verify_globals(
-            config
+        if (
+            (not cost_dict['bad'] or not config['ignore_bad']) and
+            check_runmanager(config) and
+            verify_globals(config)
         ):
             lyse.routine_storage.queue.put(cost_dict)
-        check_runmanager(config)
     elif check_runmanager(config):
         print('(Re)starting optimisation process...')
         import threading


### PR DESCRIPTION
1. Check that cost returned corresponds to the optimisation parameters requested.
   - Use lyse.routine_storage to store optimisation parameter values always.

2. Don't begin an optimisation session if:
   - runmanager has any active groups in error,
   - 'Run shot(s)' isn't checked in runmanager, or
   - Optimisation parameters are absent from the active groups in runmanager.
   - The prospective shots-per-engage in runmanager is > 1 and `ignore_bad=False`, as the latter is required for multi-shot cost evaluation.

3. If optimisation session already started, issue warning if runmanager has any of the above conditions.