### PR TITLE
Pass config to interface instantiation so that logging options aren't ignored

### DIFF
--- a/mloop_interface.py
+++ b/mloop_interface.py
@@ -25,8 +25,8 @@ class LoopInterface(Interface):
         # Retrieve configuration from file or generate from defaults
         self.config = mloop_config.get()
 
-        # Pass config arguments to parent class's __init__() so that any logging
-        # options are applied appropriately.
+        # Pass config arguments to parent class's __init__() so that any
+        # relevant specified options are applied appropriately.
         super(LoopInterface, self).__init__(**self.config)
 
         self.num_in_costs = 0

--- a/mloop_interface.py
+++ b/mloop_interface.py
@@ -22,10 +22,13 @@ def set_globals_mloop(mloop_session=None, mloop_iteration=None):
 
 class LoopInterface(Interface):
     def __init__(self):
-        super(LoopInterface, self).__init__()
-
         # Retrieve configuration from file or generate from defaults
         self.config = mloop_config.get()
+
+        # Pass config arguments to parent class's __init__() so that any logging
+        # options are applied appropriately.
+        super(LoopInterface, self).__init__(**self.config)
+
         self.num_in_costs = 0
 
     # Method called by M-LOOP upon each new iteration to determine the cost


### PR DESCRIPTION
The M-LOOP options `log_filename`, `console_log_level`, and `log_filename` need to be passed to `Interface.__init__()` in order to be applied correctly. Conveniently extra unused keyword arguments passed to the instantiation are simply ignored, so the changes in this PR just pass all of the config settings to the instantiation. That's simpler than filtering out only the required ones and it means that any options added for the `Interface` class in the future will work without any changes here.