### PR TITLE
Use global names for param_names.

### DIFF
--- a/mloop_config.py
+++ b/mloop_config.py
@@ -83,6 +83,10 @@ def get(config_path=None):
     # store number of parameters for passing to controller interface
     params["num_params"] = len(params["mloop_params"])
 
+    # get the names of the parameters, if not explicitly specified by user
+    if "param_names" not in params:
+        params["param_names"] = list(params["mloop_params"].keys())
+
     # get min boundaries for specified variables
     params["min_boundary"] = [param["min"] for param in params["mloop_params"].values()]
 


### PR DESCRIPTION
After https://github.com/michaelhush/M-LOOP/pull/54, M-LOOP now supports an optional argument `param_names` to specify names for the optimization parameters, and those names are then used for legends in plots. This PR makes `analysislib-mloop` set the parameter names to be the names of the optimization globals by default. If the user provides an explicit value for `param_names` in their `mloop_config.ini` then their value will take precedence.

M-LOOP ignores keyword arguments that it isn't programmed to interpret, so providing `param_names` shouldn't cause any backwards compatibility issues.