### PR TITLE
Add Logging

### DIFF
--- a/mloop_config.ini
+++ b/mloop_config.ini
@@ -7,6 +7,8 @@ cost_key = ["fake_result", "y"]
 maximize = true
 ignore_bad = false
 ; ignore_bad = true
+analysislib_console_log_level = "INFO"
+analysislib_file_log_level = "DEBUG"
 
 [MLOOP]
 mloop_params = {"x": {"min": -5.0, "max": 5.0, "start": -2.0} }

--- a/mloop_config.py
+++ b/mloop_config.py
@@ -1,6 +1,7 @@
 import os
 import json
 import configparser
+import logging
 
 
 def get(config_path=None):
@@ -36,6 +37,12 @@ def get(config_path=None):
         config["ANALYSIS"]["maximize"] = 'true'
         # Don't report to M-LOOP if a shot is deemed bad
         config["ANALYSIS"]["ignore_bad"] = 'true'
+        # Control log level for logging to console from analysislib-mloop. Not to be
+        # confused with MLOOP's console_log_level option for its logger.
+        config["ANALYSIS"]["analysislib_console_log_level"] = '"INFO"'
+        # Control log level for logging to file from analysislib-mloop. Not to be
+        # confused with MLOOP's file_log_level option for its logger.
+        config["ANALYSIS"]["analysislib_file_log_level"] = '"DEBUG"'
 
         # M-LOOP parameters
         config["MLOOP"] = {}

--- a/mloop_multishot.py
+++ b/mloop_multishot.py
@@ -187,15 +187,25 @@ if __name__ == '__main__':
             maximize=config['maximize'],
             x=lyse.routine_storage.params[0] if config['mock'] else None,
         )
-        if (
-            (not cost_dict['bad'] or not config['ignore_bad']) and
-            check_runmanager(config) and
-            verify_globals(config)
-        ):
-            logger.debug('Putting cost in queue.')
-            lyse.routine_storage.queue.put(cost_dict)
+        
+        if (not cost_dict['bad'] or not config['ignore_bad']):
+            if check_runmanager(config):
+                if verify_globals(config):
+                    logger.debug('Putting cost in queue.')
+                    lyse.routine_storage.queue.put(cost_dict)
+                else:
+                    message = ('NOT putting cost in queue because verify_globals '
+                               'failed.')
+                    logger.debug(message)
+            else:
+                message = ('NOT putting cost in queue because check_runmanager '
+                           'failed.')
+                logger.debug(message)
         else:
-            logger.debug('NOT putting cost in queue.')
+            message = ('NOT putting cost in queue because cost was bad and ignore_bad '
+                       'is True.')
+            logger.debug(message)
+            
     elif check_runmanager(config):
         logger.info('(Re)starting optimisation process...')
         import threading

--- a/mloop_multishot.py
+++ b/mloop_multishot.py
@@ -15,13 +15,18 @@ check_version('zprocess', '2.13.1', '3.0')
 check_version('labscript_utils', '2.12.5', '3.0')
 
 
-def configure_logging(console_log_level, file_log_level, log_filename):
+def configure_logging(config):
+    console_log_level = config['analysislib_console_log_level']
+    file_log_level = config['analysislib_console_log_level']
+    LOG_FILENAME = 'analysislib_mloop_log.txt'
+
     global logger
     logger = logging.getLogger('analysislib_mloop')
     logger.setLevel(logging.DEBUG)
     formatter = logging.Formatter(
         '%(filename)s:%(funcName)s:%(lineno)d:%(levelname)s: %(message)s'
     )
+    
     # Set up handlers if not already present from previous runs.
     if not logger.handlers:
         # Set up console handler
@@ -31,7 +36,7 @@ def configure_logging(console_log_level, file_log_level, log_filename):
         logger.addHandler(console_handler)
 
         # Set up file handler
-        file_handler = logging.FileHandler(log_filename, mode='w')
+        file_handler = logging.FileHandler(LOG_FILENAME, mode='w')
         file_handler.setLevel(file_log_level)
         file_handler.setFormatter(formatter)
         logger.addHandler(file_handler)
@@ -162,12 +167,7 @@ def cost_analysis(cost_key=(None,), maximize=True, x=None):
 
 if __name__ == '__main__':
     config = mloop_config.get()
-    
-    # TODO: Get these from config file.
-    console_log_level = logging.INFO
-    file_log_level = logging.DEBUG
-    log_filename = 'analysislib_mloop_log.txt'
-    configure_logging(console_log_level, file_log_level, log_filename)
+    configure_logging(config)
     
     if not hasattr(lyse.routine_storage, 'queue'):
         logger.info('First execution of lyse routine...')

--- a/mloop_multishot.py
+++ b/mloop_multishot.py
@@ -19,7 +19,7 @@ check_version('labscript_utils', '2.12.5', '3.0')
 
 def configure_logging(config):
     console_log_level = config['analysislib_console_log_level']
-    file_log_level = config['analysislib_console_log_level']
+    file_log_level = config['analysislib_file_log_level']
     LOG_FILENAME = 'analysislib_mloop.log'
 
     global logger

--- a/mloop_multishot.py
+++ b/mloop_multishot.py
@@ -28,7 +28,7 @@ def configure_logging(config):
     formatter = logging.Formatter(
         '%(filename)s:%(funcName)s:%(lineno)d:%(levelname)s: %(message)s'
     )
-    
+
     # Set up handlers if not already present from previous runs.
     if not logger.handlers:
         # Set up console handler
@@ -43,27 +43,27 @@ def configure_logging(config):
         file_handler.setLevel(file_log_level)
         file_handler.setFormatter(formatter)
         logger.addHandler(file_handler)
-    
+
     logger.debug('Logger configured.')
 
 
 def check_runmanager(config):
     logger.debug('Checking runmanager...')
     msgs = []
-    
+
     logger.debug('Getting globals.')
     rm_globals = rm.get_globals()
     if not all([x in rm_globals for x in config['mloop_params']]):
         msgs.append('Not all optimisation parameters present in runmanager.')
-        
+
     logger.debug('Getting run shots state.')
     if not rm.get_run_shots():
         msgs.append('Run shot(s) not selected in runmanager.')
-    
+
     logger.debug('Checking for errors in globals.')
     if rm.error_in_globals():
         msgs.append('Error in runmanager globals.')
-        
+
     logger.debug('Checking number of shots.')
     n_shots = rm.n_shots()
     if n_shots > 1 and not config['ignore_bad']:
@@ -171,7 +171,7 @@ def cost_analysis(cost_key=(None,), maximize=True, x=None):
 if __name__ == '__main__':
     config = mloop_config.get()
     configure_logging(config)
-    
+
     if not hasattr(lyse.routine_storage, 'queue'):
         logger.info('First execution of lyse routine...')
         try:
@@ -190,25 +190,24 @@ if __name__ == '__main__':
             maximize=config['maximize'],
             x=lyse.routine_storage.params[0] if config['mock'] else None,
         )
-        
-        if (not cost_dict['bad'] or not config['ignore_bad']):
+
+        if not cost_dict['bad'] or not config['ignore_bad']:
             if check_runmanager(config):
                 if verify_globals(config):
                     logger.debug('Putting cost in queue.')
                     lyse.routine_storage.queue.put(cost_dict)
                 else:
-                    message = ('NOT putting cost in queue because verify_globals '
-                               'failed.')
+                    message = 'NOT putting cost in queue because verify_globals failed.'
                     logger.debug(message)
             else:
-                message = ('NOT putting cost in queue because check_runmanager '
-                           'failed.')
+                message = 'NOT putting cost in queue because check_runmanager failed.'
                 logger.debug(message)
         else:
-            message = ('NOT putting cost in queue because cost was bad and ignore_bad '
-                       'is True.')
+            message = (
+                'NOT putting cost in queue because cost was bad and ignore_bad is True.'
+            )
             logger.debug(message)
-            
+
     elif check_runmanager(config):
         logger.info('(Re)starting optimisation process...')
         import threading

--- a/mloop_multishot.py
+++ b/mloop_multishot.py
@@ -4,6 +4,8 @@ import numpy as np
 import mloop_config
 import sys
 import logging
+import os
+from labscript_utils.setup_logging import LOG_PATH
 
 try:
     from labscript_utils import check_version
@@ -18,7 +20,7 @@ check_version('labscript_utils', '2.12.5', '3.0')
 def configure_logging(config):
     console_log_level = config['analysislib_console_log_level']
     file_log_level = config['analysislib_console_log_level']
-    LOG_FILENAME = 'analysislib_mloop_log.txt'
+    LOG_FILENAME = 'analysislib_mloop.log'
 
     global logger
     logger = logging.getLogger('analysislib_mloop')
@@ -36,7 +38,8 @@ def configure_logging(config):
         logger.addHandler(console_handler)
 
         # Set up file handler
-        file_handler = logging.FileHandler(LOG_FILENAME, mode='w')
+        full_filename = os.path.join(LOG_PATH, LOG_FILENAME)
+        file_handler = logging.FileHandler(full_filename, mode='w')
         file_handler.setLevel(file_log_level)
         file_handler.setFormatter(formatter)
         logger.addHandler(file_handler)


### PR DESCRIPTION
This PR adds basic logging to analysislib-mloop. Output is logged to the lyse console and to a file in the labscript log directory. The log level for each can be controlled independently using options in `mloop_config.ini`.

I've gone through a few iterations of adding a bunch of print statements while debugging, then removing them all before making any commits so that the output isn't overly verbose. This time around I decided to put in a bit more effort and implement proper logging instead so that the verbosity can be controlled more easily.

This is my first time using the logging module, so definitely feel free to request any changes.