### PR TITLE
Incremented upper bounds on versions for lyse etc.

### DIFF
--- a/mloop_multishot.py
+++ b/mloop_multishot.py
@@ -8,9 +8,9 @@ try:
 except ImportError:
     raise ImportError('Require labscript_utils > 2.1.0')
 
-check_version('lyse', '2.5.0', '3.0')
-check_version('zprocess', '2.13.1', '3.0')
-check_version('labscript_utils', '2.12.5', '3.0')
+check_version('lyse', '2.5.0', '4.0')
+check_version('zprocess', '2.13.1', '4.0')
+check_version('labscript_utils', '2.12.5', '4.0')
 
 
 def check_runmanager(config):


### PR DESCRIPTION
Previously `check_version()` had its upper bounds set to `'3.0'` for lyse, zprocess, and labscript_utils. This PR bumps that up to `'4.0'` for all of them since lyse and labscript_utils 3.0 have been released.

It's maybe worth mentioning that `check_version()` was removed in labscript_utils 3.0 (https://github.com/labscript-suite/labscript-utils/issues/62) but is being added back with https://github.com/labscript-suite/labscript-utils/pull/65.